### PR TITLE
Performance - merge transform api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unrealeased] - 2022-08-15
+### Modified
+- Merge .position and .rotation into .SetPositionAndRotation for better performance
+
 ## [1.0.0] - 2022-06-15
 ### Added
 - Add .samples.json file according to validation tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unrealeased] - 2022-08-15
+## [Unreleased] - 2022-08-15
 ### Modified
 - Merge .position and .rotation into .SetPositionAndRotation for better performance
 

--- a/Runtime/Behaviors/HPRoot.cs
+++ b/Runtime/Behaviors/HPRoot.cs
@@ -124,7 +124,7 @@ namespace Unity.Geospatial.HighPrecision
         /// <inheritdoc cref="HPNode.UniverseMatrix"/>
         public override double4x4 UniverseMatrix
         {
-            get { return double4x4.identity;; }
+            get { return double4x4.identity; }
         }
 
         /// <inheritdoc cref="HPNode.WorldMatrix"/>

--- a/Runtime/Behaviors/HPTransform.cs
+++ b/Runtime/Behaviors/HPTransform.cs
@@ -524,8 +524,7 @@ namespace Unity.Geospatial.HighPrecision
                 out quaternion rotation,
                 out float3 scale);
 
-            CachedUnityTransform.position = translation.ToVector3();
-            CachedUnityTransform.rotation = rotation;
+            CachedUnityTransform.SetPositionAndRotation(translation.ToVector3(), rotation); 
 
             // Since scale is impacted by translation and rotation in GetTRS(),
             // we do not directly use scale from GetTRS() to avoid loss of precision in values


### PR DESCRIPTION
### Description

Merged .postion and .rotation calls into SetPositionAndRotation in HPTransform.cs.
This will use a single c++ API call instead of 2, which is beneficial for performance.

Also removed empty statement from HPRoot.cs.


### Changes made

- Merged .postion and .rotation calls into SetPositionAndRotation in HPTransform.cs.
- Removed empty statement from HPRoot.cs.


### Checklist

Before review:

- [x] Changelog entry added under `Unreleased` section.
    - Explains the change in `Modified`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - If UI or rendering results applies, include screenshots.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as `Resolved` with `next` release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests.
    - Performance tests.
    - Integration tests.
- [x] All Tests passed.
- [x] Docs for new/changed.
    - XmlDoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
- [x] The branch name has the respective prefix.
    - `bug/` Fixing a bug
    - `feature/` New feature implementation
    - `perf/` Performance improvement
    - `refactor/` A code change that neither fixes a bug nor adds a feature
    - `doc/` Added documentation
    - `test/` Added Unit Tests
    - `build/` Changes that affect the build system or external dependencies
    - `ci/` Changes to our CI configuration files and scripts
    - `style/` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] Coding Standards are respected.
- [x] Rebase the branch if possible.

After review:

- [x] Squash and Merge
    - If no merge commits are between commits
    - Don't squash commits when they are easier to comprehend the changes when categorized.
